### PR TITLE
ci(jenkins): fix staging credentials ID

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
     DEVEL_BRANCH = "devel"
     DEVEL_BUCKET_NAME = "zextrasdoc-devel"
     PRODUCTION_CREDENTIALS = "docs.zextras.com-s3-key"
-    STAGING_CREDENTIALS = "doc-zextras-area51-s3-key"
+    STAGING_CREDENTIALS = "zextras-dev-docs-s3-key"
     REGION = 'eu-west-1'
   }
 


### PR DESCRIPTION
The `STAGING_CREDENTIALS` value was set to `doc-zextras-area51-s3-key`, which doesn't exist (or was renamed). Updated to match the credential ID used in `tech-doc`: `zextras-dev-docs-s3-key`.